### PR TITLE
Use universal newlines mode, to avoid CSV parsing errors. Fix warning…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## 0.0.3
 
+* Use universal newlines mode, to avoid CSV parsing errors.
 * Fix bug in parsing of Markdown code block.
+* Fix warning if CSV field name is empty.
 
 ## 0.0.2 (2018-10-31)
 

--- a/ocds_babel/extract.py
+++ b/ocds_babel/extract.py
@@ -13,9 +13,11 @@ def extract_codelist(fileobj, keywords, comment_tags, options):
     """
 
     # standard-maintenance-scripts validates the headers of codelist CSV files.
-    reader = csv.DictReader(StringIO(fileobj.read().decode()))
+    # Use universal newlines mode, to avoid parsing errors.
+    reader = csv.DictReader(StringIO(fileobj.read().decode(), newline=''))
     for fieldname in reader.fieldnames:
-        yield 0, '', fieldname, ''
+        if fieldname:
+            yield 0, '', fieldname, ''
 
     # Don't translate the titles of the hundreds of currencies.
     if os.path.basename(fileobj.name) != 'currency.csv':

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -80,6 +80,18 @@ def test_extract_codelist_currency():
     ])
 
 
+def test_extract_codelist_fieldname():
+    assert_result('test.csv', b'Code,', extract_codelist, [
+        (0, '', 'Code', ''),
+    ])
+
+
+def test_extract_codelist_newline():
+    assert_result('test.csv', b'Code\rfoo', extract_codelist, [
+        (0, '', 'Code', ''),
+    ])
+
+
 def test_extract_schema():
     assert_result('schema.json', schema, extract_schema, [
         (1, '', 'foo', ['/title/oneOf/0/title']),


### PR DESCRIPTION
… if CSV field name is empty.